### PR TITLE
Stop exposing an internal enum

### DIFF
--- a/door.inc
+++ b/door.inc
@@ -323,7 +323,7 @@ between OPEN and CLOSED without CLOSING or OPENING in between.
 ==============================================================================*/
 
 
-enum E_DOOR_DATA {
+static enum E_DOOR_DATA {
 	door_objectid,
 	door_model,
 	Button:door_buttonArray[MAX_BUTTONS_PER_DOOR],


### PR DESCRIPTION
- That enum should be used only internally
- Fixes collision with open-vehicle-plus library